### PR TITLE
Typo: “comma seperated” → comma-separated

### DIFF
--- a/po/aa.po
+++ b/po/aa.po
@@ -163,7 +163,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/ab.po
+++ b/po/ab.po
@@ -161,7 +161,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/ae.po
+++ b/po/ae.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/af.po
+++ b/po/af.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/ak.po
+++ b/po/ak.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/am.po
+++ b/po/am.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/an.po
+++ b/po/an.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/ar.po
+++ b/po/ar.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/as.po
+++ b/po/as.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/ast.po
+++ b/po/ast.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/av.po
+++ b/po/av.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/ay.po
+++ b/po/ay.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/az.po
+++ b/po/az.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/ba.po
+++ b/po/ba.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/be.po
+++ b/po/be.po
@@ -170,7 +170,7 @@ msgid "Annotation Tags"
 msgstr "Тэгі анатацыі"
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr "Тэгі для гэтай анатацыі, падзеленыя коскамі"
 
 #: ../src/constants.vala:62

--- a/po/bg.po
+++ b/po/bg.po
@@ -153,7 +153,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/bh.po
+++ b/po/bh.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/bi.po
+++ b/po/bi.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/bm.po
+++ b/po/bm.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/bn.po
+++ b/po/bn.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/bo.po
+++ b/po/bo.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/bookworm.pot
+++ b/po/bookworm.pot
@@ -164,7 +164,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/br.po
+++ b/po/br.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/bs.po
+++ b/po/bs.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/ca.po
+++ b/po/ca.po
@@ -171,7 +171,7 @@ msgid "Annotation Tags"
 msgstr "Etiquetes d’anotació"
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr "Etiquetes separades per comes per a aquesta anotació"
 
 #: ../src/constants.vala:62

--- a/po/ce.po
+++ b/po/ce.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/ch.po
+++ b/po/ch.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/ckb.po
+++ b/po/ckb.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/co.po
+++ b/po/co.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/com.github.babluboy.bookworm.pot
+++ b/po/com.github.babluboy.bookworm.pot
@@ -164,7 +164,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:63
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:64

--- a/po/cr.po
+++ b/po/cr.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/cs.po
+++ b/po/cs.po
@@ -169,7 +169,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/cu.po
+++ b/po/cu.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/cv.po
+++ b/po/cv.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/cy.po
+++ b/po/cy.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/da.po
+++ b/po/da.po
@@ -167,7 +167,7 @@ msgid "Annotation Tags"
 msgstr "Note tags"
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr "Kommaseparerede tags til denne note"
 
 #: ../src/constants.vala:62

--- a/po/de.po
+++ b/po/de.po
@@ -173,7 +173,7 @@ msgid "Annotation Tags"
 msgstr "Kommentar-Schlagwörter"
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr "Komma getrennte Schlagwörter für diese Anmerkung"
 
 #: ../src/constants.vala:62

--- a/po/dv.po
+++ b/po/dv.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/dz.po
+++ b/po/dz.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/ee.po
+++ b/po/ee.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/el.po
+++ b/po/el.po
@@ -183,7 +183,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/en_AU.po
+++ b/po/en_AU.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/en_CA.po
+++ b/po/en_CA.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/eo.po
+++ b/po/eo.po
@@ -153,7 +153,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/es.po
+++ b/po/es.po
@@ -171,7 +171,7 @@ msgid "Annotation Tags"
 msgstr "Etiquetas de anotación"
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr "Etiquetas separadas por comas para esta anotación"
 
 #: ../src/constants.vala:62

--- a/po/es_MX.po
+++ b/po/es_MX.po
@@ -180,7 +180,7 @@ msgid "Annotation Tags"
 msgstr "Notas"
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr "Etiquetas separadas por comas para esta anotación"
 
 #: ../src/constants.vala:62

--- a/po/et.po
+++ b/po/et.po
@@ -168,7 +168,7 @@ msgid "Annotation Tags"
 msgstr "Annotatsioonide sildid"
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr "Selle annotatsiooni sildid (komadega eraldatud)"
 
 #: ../src/constants.vala:62

--- a/po/eu.po
+++ b/po/eu.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/fa.po
+++ b/po/fa.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/ff.po
+++ b/po/ff.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/fi.po
+++ b/po/fi.po
@@ -153,7 +153,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/fj.po
+++ b/po/fj.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/fo.po
+++ b/po/fo.po
@@ -153,7 +153,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/fr.po
+++ b/po/fr.po
@@ -175,7 +175,7 @@ msgid "Annotation Tags"
 msgstr "Étiquettes de notes"
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr "Étiquettes séparées par des virgules pour cette note"
 
 #: ../src/constants.vala:62

--- a/po/fr_CA.po
+++ b/po/fr_CA.po
@@ -153,7 +153,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/fy.po
+++ b/po/fy.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/ga.po
+++ b/po/ga.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/gd.po
+++ b/po/gd.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/gl.po
+++ b/po/gl.po
@@ -180,7 +180,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/gn.po
+++ b/po/gn.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/gu.po
+++ b/po/gu.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/gv.po
+++ b/po/gv.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/ha.po
+++ b/po/ha.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/he.po
+++ b/po/he.po
@@ -153,7 +153,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/hi.po
+++ b/po/hi.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/ho.po
+++ b/po/ho.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/hr.po
+++ b/po/hr.po
@@ -154,7 +154,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/ht.po
+++ b/po/ht.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/hu.po
+++ b/po/hu.po
@@ -153,7 +153,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/hy.po
+++ b/po/hy.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/hz.po
+++ b/po/hz.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/ia.po
+++ b/po/ia.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/id.po
+++ b/po/id.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/ie.po
+++ b/po/ie.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/ig.po
+++ b/po/ig.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/ii.po
+++ b/po/ii.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/ik.po
+++ b/po/ik.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/io.po
+++ b/po/io.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/is.po
+++ b/po/is.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/it.po
+++ b/po/it.po
@@ -177,7 +177,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/iu.po
+++ b/po/iu.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/ja.po
+++ b/po/ja.po
@@ -173,7 +173,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/jv.po
+++ b/po/jv.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/ka.po
+++ b/po/ka.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/kg.po
+++ b/po/kg.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/ki.po
+++ b/po/ki.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/kj.po
+++ b/po/kj.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/kk.po
+++ b/po/kk.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/kl.po
+++ b/po/kl.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/km.po
+++ b/po/km.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/kn.po
+++ b/po/kn.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/ko.po
+++ b/po/ko.po
@@ -153,7 +153,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/kr.po
+++ b/po/kr.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/ks.po
+++ b/po/ks.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/ku.po
+++ b/po/ku.po
@@ -183,7 +183,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/kv.po
+++ b/po/kv.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/kw.po
+++ b/po/kw.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/ky.po
+++ b/po/ky.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/la.po
+++ b/po/la.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/lb.po
+++ b/po/lb.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/lg.po
+++ b/po/lg.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/li.po
+++ b/po/li.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/ln.po
+++ b/po/ln.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/lo.po
+++ b/po/lo.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/lt.po
+++ b/po/lt.po
@@ -154,7 +154,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/lu.po
+++ b/po/lu.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/lv.po
+++ b/po/lv.po
@@ -153,7 +153,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/mg.po
+++ b/po/mg.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/mh.po
+++ b/po/mh.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/mi.po
+++ b/po/mi.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/mk.po
+++ b/po/mk.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/ml.po
+++ b/po/ml.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/mn.po
+++ b/po/mn.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/mo.po
+++ b/po/mo.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/mr.po
+++ b/po/mr.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/ms.po
+++ b/po/ms.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/mt.po
+++ b/po/mt.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/my.po
+++ b/po/my.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/na.po
+++ b/po/na.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -169,7 +169,7 @@ msgid "Annotation Tags"
 msgstr "Anmerkningstagger"
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr "Kommainndelt liste over tagger for denne anmerkningen"
 
 #: ../src/constants.vala:62

--- a/po/nd.po
+++ b/po/nd.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/ne.po
+++ b/po/ne.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/ng.po
+++ b/po/ng.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/nl.po
+++ b/po/nl.po
@@ -180,7 +180,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/nn.po
+++ b/po/nn.po
@@ -153,7 +153,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/nr.po
+++ b/po/nr.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/nv.po
+++ b/po/nv.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/ny.po
+++ b/po/ny.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/oc.po
+++ b/po/oc.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/oj.po
+++ b/po/oj.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/om.po
+++ b/po/om.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/or.po
+++ b/po/or.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/os.po
+++ b/po/os.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/pa.po
+++ b/po/pa.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/pi.po
+++ b/po/pi.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/pl.po
+++ b/po/pl.po
@@ -172,7 +172,7 @@ msgid "Annotation Tags"
 msgstr "Znaczniki przypisów"
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr "Lista tagów, oddzielonych przecinkami, dla tego przypisu"
 
 #: ../src/constants.vala:62

--- a/po/ps.po
+++ b/po/ps.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/pt.po
+++ b/po/pt.po
@@ -160,7 +160,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -169,7 +169,7 @@ msgid "Annotation Tags"
 msgstr "Anotações"
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/qu.po
+++ b/po/qu.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/rm.po
+++ b/po/rm.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/rn.po
+++ b/po/rn.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/ro.po
+++ b/po/ro.po
@@ -154,7 +154,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/ru.po
+++ b/po/ru.po
@@ -176,7 +176,7 @@ msgid "Annotation Tags"
 msgstr "Примечание"
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/rue.po
+++ b/po/rue.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/rw.po
+++ b/po/rw.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/sa.po
+++ b/po/sa.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/sc.po
+++ b/po/sc.po
@@ -172,7 +172,7 @@ msgid "Annotation Tags"
 msgstr "Etichetas de sas notas"
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr "Eichetas separadas dae vìrgulas pro custa nota"
 
 #: ../src/constants.vala:62

--- a/po/sd.po
+++ b/po/sd.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/se.po
+++ b/po/se.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/sg.po
+++ b/po/sg.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/si.po
+++ b/po/si.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/sk.po
+++ b/po/sk.po
@@ -153,7 +153,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/sl.po
+++ b/po/sl.po
@@ -154,7 +154,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/sm.po
+++ b/po/sm.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/sma.po
+++ b/po/sma.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/sn.po
+++ b/po/sn.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/so.po
+++ b/po/so.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/sq.po
+++ b/po/sq.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/sr.po
+++ b/po/sr.po
@@ -176,7 +176,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/sr_Latn.po
+++ b/po/sr_Latn.po
@@ -182,7 +182,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/ss.po
+++ b/po/ss.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/st.po
+++ b/po/st.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/su.po
+++ b/po/su.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/sv.po
+++ b/po/sv.po
@@ -168,7 +168,7 @@ msgid "Annotation Tags"
 msgstr "Anteckningstaggar"
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr "Kommaseparerade taggar för denna anteckning"
 
 #: ../src/constants.vala:62

--- a/po/sw.po
+++ b/po/sw.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/ta.po
+++ b/po/ta.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/te.po
+++ b/po/te.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/tg.po
+++ b/po/tg.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/th.po
+++ b/po/th.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/ti.po
+++ b/po/ti.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/tk.po
+++ b/po/tk.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/tl.po
+++ b/po/tl.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/tn.po
+++ b/po/tn.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/to.po
+++ b/po/to.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/tr.po
+++ b/po/tr.po
@@ -172,7 +172,7 @@ msgid "Annotation Tags"
 msgstr "Açıklamalar"
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/ts.po
+++ b/po/ts.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/tt.po
+++ b/po/tt.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/tw.po
+++ b/po/tw.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/ty.po
+++ b/po/ty.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/ug.po
+++ b/po/ug.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/uk.po
+++ b/po/uk.po
@@ -171,7 +171,7 @@ msgid "Annotation Tags"
 msgstr "Теги анотації"
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr "Комбінація розділених тегів для цієї анотації"
 
 #: ../src/constants.vala:62

--- a/po/ur.po
+++ b/po/ur.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/uz.po
+++ b/po/uz.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/ve.po
+++ b/po/ve.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/vi.po
+++ b/po/vi.po
@@ -164,7 +164,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/vo.po
+++ b/po/vo.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/wa.po
+++ b/po/wa.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/wo.po
+++ b/po/wo.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/xh.po
+++ b/po/xh.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/yi.po
+++ b/po/yi.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/yo.po
+++ b/po/yo.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/za.po
+++ b/po/za.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/zh.po
+++ b/po/zh.po
@@ -162,7 +162,7 @@ msgid "Annotation Tags"
 msgstr "注释标签"
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr "本注释逗号分隔的标签"
 
 #: ../src/constants.vala:62

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -170,7 +170,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/zh_HK.po
+++ b/po/zh_HK.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/po/zu.po
+++ b/po/zu.po
@@ -152,7 +152,7 @@ msgid "Annotation Tags"
 msgstr ""
 
 #: ../src/constants.vala:61
-msgid "Comma seperated tags for this annotation"
+msgid "Comma-separated tags for this annotation"
 msgstr ""
 
 #: ../src/constants.vala:62

--- a/src/constants.vala
+++ b/src/constants.vala
@@ -60,7 +60,7 @@ namespace BookwormApp.Constants {
 	public const string TEXT_FOR_INFO_TAB_SEARCHRESULTS = _("Search Results");
 	public const string TEXT_FOR_INFO_TAB_ANNOTATIONS = _("Annotations");
 	public const string TEXT_FOR_ANNOTATION_TAG = _("Annotation Tags");
-	public const string TEXT_FOR_ANNOTATION_TAG_ENTRY = _("Comma seperated tags for this annotation");
+	public const string TEXT_FOR_ANNOTATION_TAG_ENTRY = _("Comma-separated tags for this annotation");
 	public const string TEXT_FOR_ANNOTATION = _("Add notes for : ");
 	public const string TEXT_FOR_ANNOTATIONS_FOUND = _("Click on a link to jump to an annotated section");
 	public const string TEXT_FOR_ANNOTATIONS_NOT_FOUND = _("No annotations set in BBB, right click the page of a book and choose annotation from the context menu to add annotations");

--- a/src/constants.vala.in
+++ b/src/constants.vala.in
@@ -60,7 +60,7 @@ namespace BookwormApp.Constants {
 	public const string TEXT_FOR_INFO_TAB_SEARCHRESULTS = _("Search Results");
 	public const string TEXT_FOR_INFO_TAB_ANNOTATIONS = _("Annotations");
 	public const string TEXT_FOR_ANNOTATION_TAG = _("Annotation Tags");
-	public const string TEXT_FOR_ANNOTATION_TAG_ENTRY = _("Comma seperated tags for this annotation");
+	public const string TEXT_FOR_ANNOTATION_TAG_ENTRY = _("Comma-separated tags for this annotation");
 	public const string TEXT_FOR_ANNOTATION = _("Add notes for : ");
 	public const string TEXT_FOR_ANNOTATIONS_FOUND = _("Click on a link to jump to an annotated section");
 	public const string TEXT_FOR_ANNOTATIONS_NOT_FOUND = _("No annotations set in BBB, right click the page of a book and choose annotation from the context menu to add annotations");


### PR DESCRIPTION
I simply ran `git grep -l "Comma seperated" | xargs sed -i "s/Comma seperated/Comma-separated/g"`. This way, the existing translations for the string with the typo are not affected.