### PR TITLE
Update desktop entry to use standardised Keywords key.

### DIFF
--- a/data/com.github.babluboy.bookworm.desktop
+++ b/data/com.github.babluboy.bookworm.desktop
@@ -9,4 +9,4 @@ Icon=com.github.babluboy.bookworm
 Terminal=false
 Type=Application
 X-GNOME-Gettext-Domain=bookworm
-X-GNOME-Keywords=Bookworm;Ebook;Reader;Epub;Mobi;Comic;Cbr;Cbz;Pdf;
+Keywords=Bookworm;Ebook;Reader;Epub;Mobi;Comic;Cbr;Cbz;Pdf;


### PR DESCRIPTION
Update desktop entry to use standardised Keywords key,
instead of X-GNOME-Keywords.

Also remove unnecessary execute permissions from desktop
file.