### PR TITLE
Meson: install scripts

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -11,6 +11,21 @@ foreach i : icon_sizes
     )
 endforeach
 
+
+scripts_dir = join_paths(get_option('datadir'), 'bookworm', 'scripts')
+
+install_data(
+  join_paths('scripts', meson.project_name() + '.search.sh'),
+  install_dir: join_paths(scripts_dir, 'tasks'),
+  install_mode: 'rwxr-xr-x'
+)
+
+install_subdir(
+  'scripts/mobi_lib',
+  install_dir: scripts_dir,
+  install_mode: 'rwxr-xr-x'
+)
+
 i18n.merge_file(
     input: meson.project_name() + '.desktop.in',
     output: meson.project_name() + '.desktop',


### PR DESCRIPTION
It looks like when you switched to meson that the scripts got forgotten.

I've also taken care to ensure that the permissions are the same as specified when you were using CMake.