### PR TITLE
Fix typo and wrong icon name

### DIFF
--- a/src/constants.vala.in
+++ b/src/constants.vala.in
@@ -56,7 +56,7 @@ namespace BookwormApp.Constants {
 	public const string TEXT_FOR_INFO_TAB_BOOKMARKS = _("Bookmarks");
 	public const string TEXT_FOR_BOOKMARKS = _("Bookmark #NNN for Section PPP");
 	public const string TEXT_FOR_BOOKMARKS_FOUND = _("Click on a link to jump to bookmarked section");
-	public const string TEXT_FOR_BOOKMARKS_NOT_FOUND = _("No bookmarks set in BBB, click the bookworm icon on the header bar to boomark the page");
+	public const string TEXT_FOR_BOOKMARKS_NOT_FOUND = _("No bookmarks set in BBB, click the bookmark icon on the header bar to bookmark the page");
 	public const string TEXT_FOR_INFO_TAB_DICTRESULTS = _("Word Meaning");
 	public const string TEXT_FOR_INFO_TAB_SEARCHRESULTS = _("Search Results");
 	public const string TEXT_FOR_INFO_TAB_ANNOTATIONS = _("Annotations");


### PR DESCRIPTION
### Changes Summary

* Fix typo: boomark→bookmark
* Fix wrong icon name: bookworm icon→bookmark icon

See [the comments to this string in Weblate](https://hosted.weblate.org/translate/bookworm/bookworm/ja/?checksum=4ea285e1d4db3e56#comments) for reasons
