### PR TITLE
Toggle fullscreen mode on F11

### DIFF
--- a/data/com.github.babluboy.bookworm.gschema.xml
+++ b/data/com.github.babluboy.bookworm.gschema.xml
@@ -80,6 +80,10 @@
 				<default>"LIBRARY_MODE_GRID"</default>
 				<summary>Save the library view mode</summary>
 		</key>
+		<key name="is-fullscreen" type="b">
+				<default>false</default>
+				<summary>Save fullscreen state</summary>
+		</key>
 		<key name="list-of-profile-colors" type="s">
         <default>"#000000,#fbfbfb,#E8ED00,#586e75,#fdf6e3,#87FF2B,#93a1a1,#002b36,#3465A4"</default>
         <summary>

--- a/src/bookworm.vala
+++ b/src/bookworm.vala
@@ -222,6 +222,8 @@ public class BookwormApp.Bookworm : Granite.Application {
 			window.key_press_event.connect (BookwormApp.Shortcuts.handleKeyPress);
 			window.key_release_event.connect (BookwormApp.Shortcuts.handleKeyRelease);
 
+			window.window_state_event.connect (BookwormApp.AppWindow.handleWindowStateEvents);
+
 			isBookwormRunning = true;
 			debug("Completed creating an instance of Bookworm");
 		}else{

--- a/src/settings.vala
+++ b/src/settings.vala
@@ -42,6 +42,7 @@ public class BookwormApp.Settings : Granite.Services.Settings {
   public string book_being_read { get; set; }
   public bool is_two_page_enabled { get; set; }
   public string current_info_tab { get; set; }
+  public bool is_fullscreen { get; set; }
 
   public static Settings get_instance () {
     if (instance == null) {

--- a/src/shortcuts.vala
+++ b/src/shortcuts.vala
@@ -91,16 +91,22 @@ public class BookwormApp.Shortcuts: Gtk.Widget {
         }
       }
     }
-    
+
     //Escape key pressed: remove full screen
     if (ev.keyval == Gdk.Key.Escape) {
       BookwormApp.AppWindow.book_reading_footer_box.show();
       BookwormApp.Bookworm.window.unfullscreen();
     }
-    //F11 key pressed: enter full screen
+    //F11 key pressed: toggle full screen
     if (ev.keyval == Gdk.Key.F11) {
-      BookwormApp.AppWindow.book_reading_footer_box.hide();
-      BookwormApp.Bookworm.window.fullscreen();
+      if (settings.is_fullscreen) {
+        BookwormApp.AppWindow.book_reading_footer_box.show();
+        BookwormApp.Bookworm.window.unfullscreen();
+      }else{
+        BookwormApp.AppWindow.book_reading_footer_box.hide();
+        BookwormApp.Bookworm.window.fullscreen();
+      }
+      return true;
     }
     //Ctrl+Q Key pressed: Close Bookworm completely
     if (BookwormApp.Shortcuts.isControlKeyPressed && (ev.keyval == Gdk.Key.Q || ev.keyval == Gdk.Key.q)) {

--- a/src/window.vala
+++ b/src/window.vala
@@ -569,4 +569,15 @@ public class BookwormApp.AppWindow {
     public static void on_info_bar_closed(){
         BookwormApp.AppWindow.infobar.hide();
     }
+
+    public static bool handleWindowStateEvents(Gdk.EventWindowState ev){
+        if (ev.type == Gdk.EventType.WINDOW_STATE) {
+            if ((ev.window.get_state() & Gdk.WindowState.FULLSCREEN) == 0) {
+                settings.is_fullscreen = false;
+            }else{
+                settings.is_fullscreen = true;
+            }
+        }
+        return false;
+    }
 }


### PR DESCRIPTION
This PR changes the behavior of the app when F11 key is pressed. Instead of always enabling fullscreen mode, it toggles between fullscreen and normal modes.

closes #194 