### PR TITLE
Fix shortcuts behaviour

### DIFF
--- a/src/dialog.vala
+++ b/src/dialog.vala
@@ -984,15 +984,15 @@ class BookwormApp.ShortcutsToActionAssocViewHelper {
 
         //if (rownum == 0) {
             shortcutGroupBox.draw.connect_after ((ctx) => {
-                groupHeaderBox.set_size_request (shortcutGroupBox.get_allocated_width () - 5, -1);
+                groupHeaderBox.set_size_request (shortcutGroupBox.get_allocated_width () - 25, -1);
                 return false;
             });
             shortcutsBox.draw.connect_after ((ctx) => {
-                shortcutsHeaderBox.set_size_request (shortcutsBox.get_allocated_width () - 5, -1);
+                shortcutsHeaderBox.set_size_request (shortcutsBox.get_allocated_width () - 25, -1);
                 return false;
             });
             actionBox.draw.connect_after ((ctx) => {
-                actionHeaderBox.set_size_request (actionBox.get_allocated_width () - 5, -1);
+                actionHeaderBox.set_size_request (actionBox.get_allocated_width () - 25, -1);
                 return false;
             });
         //}

--- a/src/shortcuts.vala
+++ b/src/shortcuts.vala
@@ -42,6 +42,19 @@ public class BookwormApp.Shortcuts {
                         ", uistring: " + shortcutStruct.to_ui_string() +
                         ", modifier: " + shortcutStruct.get_modifier_type().to_string()
                         );
+                    if (BookwormApp.AppHeaderBar.headerSearchBar.has_focus) {
+                        unichar unicode_keyval = Gdk.keyval_to_unicode (shortcutStruct.keyval);
+                        bool isNotModifier = shortcutStruct.get_modifier_type () == 0;
+                        bool isprintable = isNotModifier && unicode_keyval.validate() && unicode_keyval.isgraph();
+                        if (isprintable ||
+                            shortcutStruct.keyval == Gdk.Key.BackSpace ||
+                            shortcutStruct.keyval == Gdk.Key.Return ||
+                            shortcutStruct.keyval == Gdk.Key.Left ||
+                            shortcutStruct.keyval == Gdk.Key.Right
+                            ) {
+                            return false;
+                        }
+                    }
                     return BookwormApp.Shortcuts.dispatchByActionName (assoc.action, shortcutStruct);
                 });
             });


### PR DESCRIPTION
This PR fixes two bugs:
 - in shortcuts settings the list header kept requesting increasingly large sizes causing the dialog window to become broader and broader;
 - there was a conflict between shortcuts and a search entry.