### PR TITLE
Adapt left-over Python 2 code

### DIFF
--- a/data/scripts/mobi_lib/mobiml2xhtml.py
+++ b/data/scripts/mobi_lib/mobiml2xhtml.py
@@ -241,18 +241,18 @@ class MobiMLConverter(object):
                     self.path.append(tname)
                 elif ttype == 'end':
                     if tname != self.path[-1]:
-                        print ('improper nesting: ', self.path, tname, ttype)
+                        print('improper nesting: ', self.path, tname, ttype)
                         if tname not in self.path:
                             # handle case of end tag with no beginning by injecting empty begin tag
                             taginfo = ('begin', tname, None)
                             htmlstr += self.processtag(taginfo)
-                            print "     - fixed by injecting empty start tag ", tname
+                            print('     - fixed by injecting empty start tag ', tname)
                             self.path.append(tname)
                         elif len(self.path) >  1 and tname == self.path[-2]:
                             # handle case of dangling missing end
                             taginfo = ('end', self.path[-1], None)
                             htmlstr += self.processtag(taginfo)
-                            print "     - fixed by injecting end tag ", self.path[-1]
+                            print('     - fixed by injecting end tag ', self.path[-1])
                             self.path.pop()
                     self.path.pop()
 
@@ -504,18 +504,18 @@ def main(argv=sys.argv):
         infile = argv[1]
 
     try:
-        print 'Converting Mobi Markup Language to XHTML'
+        print('Converting Mobi Markup Language to XHTML')
         mlc = MobiMLConverter(infile)
-        print 'Processing ...'
+        print('Processing ...')
         htmlstr, css, cssname = mlc.processml()
         outname = infile.rsplit('.',1)[0] + '_converted.html'
         file(outname, 'wb').write(htmlstr)
         file(cssname, 'wb').write(css)
-        print 'Completed'
-        print 'XHTML version of book can be found at: ' + outname
+        print('Completed')
+        print('XHTML version of book can be found at: ', outname)
 
-    except ValueError, e:
-        print "Error: %s" % e
+    except ValueError as e:
+        print("Error: %s" % e)
         return 1
 
     return 0


### PR DESCRIPTION
Fixes #330 although I know this would just be an intermediate solution if you still plan to implement the necessary bits in Vala to get rid of the Python code.  But these minor changes would allow the installation on any Debian or Ubuntu based distribution in the meanwhile (cf. flathub/com.github.babluboy.bookworm#15 for instance).