### PR TITLE
fix print in case of python env isn't python2

### DIFF
--- a/data/scripts/mobi_lib/mobiml2xhtml.py
+++ b/data/scripts/mobi_lib/mobiml2xhtml.py
@@ -246,13 +246,13 @@ class MobiMLConverter(object):
                             # handle case of end tag with no beginning by injecting empty begin tag
                             taginfo = ('begin', tname, None)
                             htmlstr += self.processtag(taginfo)
-                            print "     - fixed by injecting empty start tag ", tname
+                            print ("     - fixed by injecting empty start tag ", tname)
                             self.path.append(tname)
                         elif len(self.path) >  1 and tname == self.path[-2]:
                             # handle case of dangling missing end
                             taginfo = ('end', self.path[-1], None)
                             htmlstr += self.processtag(taginfo)
-                            print "     - fixed by injecting end tag ", self.path[-1]
+                            print ("     - fixed by injecting end tag ", self.path[-1])
                             self.path.pop()
                     self.path.pop()
 
@@ -504,18 +504,18 @@ def main(argv=sys.argv):
         infile = argv[1]
 
     try:
-        print 'Converting Mobi Markup Language to XHTML'
+        print ('Converting Mobi Markup Language to XHTML')
         mlc = MobiMLConverter(infile)
-        print 'Processing ...'
+        print ('Processing ...')
         htmlstr, css, cssname = mlc.processml()
         outname = infile.rsplit('.',1)[0] + '_converted.html'
         file(outname, 'wb').write(htmlstr)
         file(cssname, 'wb').write(css)
-        print 'Completed'
-        print 'XHTML version of book can be found at: ' + outname
+        print ('Completed')
+        print ('XHTML version of book can be found at: ' + outname)
 
     except ValueError, e:
-        print "Error: %s" % e
+        print ("Error: %s" % e)
         return 1
 
     return 0


### PR DESCRIPTION
Hello,

I tried to install bookworm on pop os 21.04. Had some errors on the post install script :

Paramétrage de bookworm (1.1.2+git20200823-1) ...
  File "/usr/share/com.github.babluboy.bookworm/scripts/mobi_lib/mobiml2xhtml.py", line 507
    print 'Converting Mobi Markup Language to XHTML'
          ^
SyntaxError: Missing parentheses in call to 'print'. Did you mean print('Converting Mobi Markup Language to XHTML')?

this should do the work I did copy what you did on other print on this file