### PR TITLE
XmlParser: pass non null user_data, to SAXHandler.user_parse_file to fix libxml assertion errors

### DIFF
--- a/src/xmlHandler.vala
+++ b/src/xmlHandler.vala
@@ -142,11 +142,10 @@ public class BookwormApp.XmlParser {
     public void parseXML (string path) {
         Parser.init ();
         var handler = SAXHandler ();
-        void* user_data = null;
         handler.startElement = start_element;
         handler.characters = get_text;
         handler.endElement = end_element;
-        handler.user_parse_file (user_data, path);
+        handler.user_parse_file (this, path);
         Parser.cleanup ();
     }
 


### PR DESCRIPTION
Currently bookworm cannot open .epub files on archlinux: 
 - error "Invalid content found. Ensure there is a valid eBook file here" is reported
 - --debug provides traces:
```log
[DEBUG 15:50:00.511727] xmlHandler.vala:131: Reading XML to extract data for input set #0:rootfiles/rootfile/full-path
[FATAL 15:50:00.511782] bookworm_app_xml_parser_start_element: assertion 'self != NULL' failed
[FATAL 15:50:00.511791] bookworm_app_xml_parser_start_element: assertion 'self != NULL' failed
[FATAL 15:50:00.511801] bookworm_app_xml_parser_start_element: assertion 'self != NULL' failed
[FATAL 15:50:00.511807] bookworm_app_xml_parser_end_element: assertion 'self != NULL' failed
[FATAL 15:50:00.511814] bookworm_app_xml_parser_end_element: assertion 'self != NULL' failed
[FATAL 15:50:00.511821] bookworm_app_xml_parser_end_element: assertion 'self != NULL' failed
[INFO 15:50:00.511846] xmlHandler.vala:138: [END] [FUNCTION:extractDataFromXML] extracting xml from file=/tmp/com.github.babluboy.bookworm/abc.epub/META-INF/container.xml
```

Issue can be fixed by passing dummy non-null (empty string) user data, instead of null

System: archlinux
libxml2: 2.14.3-1

Fixes #401 